### PR TITLE
Support reformatting message via regex_replace()

### DIFF
--- a/push.cpp
+++ b/push.cpp
@@ -143,6 +143,8 @@ class CPushMod : public CModule
 			defaults["message_priority"] = "0";
 			defaults["message_sound"] = "";
 			defaults["message_escape"] = "";
+			defaults["message_input"] = "(.*)";
+			defaults["message_output"] = "$1";
 
 			// Notification conditions
 			defaults["away_only"] = "no";
@@ -298,6 +300,8 @@ class CPushMod : public CModule
 			CString service_url;
 			CString service_auth;
 			MCString params;
+
+            message_content = regex_replace(message_content, regex(options["message_input"]), options["message_output"]);
 
 			// Service-specific profiles
 			if (service == "pushbullet")


### PR DESCRIPTION
This is more an issue than a pull request, since I couldn't get my IDE to properly build the project and I didn't do much C++ in the pasts, I was unable to test or verify this code's integrity.

The main idea is to match any `message_content` from input against a user-defined regex and restructure that message using this regex inside an output string, all of that using `regex_replace()`.
This may be a little advanced for most users, but fairly its an advanced solution for an advanced problem; being able to simplify the output of messages that may be sent automatically into an IRC chat.

If this proposal is to be denied, I want to ask for further instructions about the development environment and using the result library inside ZNC, so that I can include this change in my own ZNC instance only.